### PR TITLE
update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         additional_dependencies:
           - pandas-stubs>=2.2.0.240316
           - pydantic>=2.5.2,<3.0.0
-          - types-openpyxl>=3.1.0.20240311
+          - types-openpyxl>=3.1.0.20240331
           - types-python-dateutil>=2.8.19.20240316
           - types-requests>=2.31.0.20240311
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/poetry.lock
+++ b/poetry.lock
@@ -1084,13 +1084,13 @@ files = [
 
 [[package]]
 name = "types-openpyxl"
-version = "3.1.0.20240311"
+version = "3.1.0.20240331"
 description = "Typing stubs for openpyxl"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-openpyxl-3.1.0.20240311.tar.gz", hash = "sha256:4ad31445ff313d6ae79a176a2e31d4232378709cab68b4e9107fb167de14c37f"},
-    {file = "types_openpyxl-3.1.0.20240311-py3-none-any.whl", hash = "sha256:f1e32639a8d6d26528c342ee4566743ce4149cc5b35b591c46a7370db39bc72b"},
+    {file = "types-openpyxl-3.1.0.20240331.tar.gz", hash = "sha256:b36047aae13f5ea55f243dd754a12d041149685351e09a9ad7e922f497e5bed7"},
+    {file = "types_openpyxl-3.1.0.20240331-py3-none-any.whl", hash = "sha256:e324cf4f03caf7f93a4a73e90ff0a3293f474481a5f625669d271f60d2f37023"},
 ]
 
 [[package]]
@@ -1191,4 +1191,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "e9f9db6641c232a4a534496ffeb9b3d023d486d06cc33cfe9a3cb81f5ef16c7d"
+content-hash = "20f9e64ee05819981d67abc40a0a2ed320ab1e6b1b7a54b934c34bf238357a54"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ pandas-stubs = "^2.2.1.240316"
 pre-commit = "^3.7.0"
 pytest = "^8.1.1"
 ruff = "^0.3.4"
-types-openpyxl = "^3.1.0.20240311"
+types-openpyxl = "^3.1.0.20240331"
 types-python-dateutil = "^2.9.0.20240316"
 types-requests = "^2.31.0.20240311"
 


### PR DESCRIPTION
* Bump types-openpyxl from 3.1.0.20240311 to 3.1.0.20240331

Bumps [types-openpyxl](https://github.com/python/typeshed) from 3.1.0.20240311 to 3.1.0.20240331.
- [Commits](https://github.com/python/typeshed/commits)

---
updated-dependencies:
- dependency-name: types-openpyxl dependency-type: direct:development update-type: version-update:semver-patch ...



* amended pyproject.toml and .pre-commit-config.yaml accordingly

---------