### PR TITLE
Keep SHA256SUMS out of dist/ for PyPI publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,13 +157,15 @@ jobs:
           set -euo pipefail
           uv build
           uvx twine check dist/*
-          (cd dist && sha256sum *.whl *.tar.gz > SHA256SUMS && cat SHA256SUMS)
+          (cd dist && sha256sum *.whl *.tar.gz > ../SHA256SUMS && cat ../SHA256SUMS)
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
-          path: dist/
+          path: |
+            dist/
+            SHA256SUMS
           if-no-files-found: error
 
   publish_testpypi:
@@ -182,13 +184,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
-          path: dist
+          path: .
 
       - name: Verify distribution checksums
         run: |
           set -euo pipefail
           cd dist
-          sha256sum -c SHA256SUMS
+          sha256sum -c ../SHA256SUMS
 
       - name: Publish distributions to TestPyPI (OIDC)
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -212,13 +214,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
-          path: dist
+          path: .
 
       - name: Verify distribution checksums
         run: |
           set -euo pipefail
           cd dist
-          sha256sum -c SHA256SUMS
+          sha256sum -c ../SHA256SUMS
 
       - name: Publish distributions to PyPI (OIDC)
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## Summary
- Write `SHA256SUMS` next to `dist/` instead of inside it.
- `gh-action-pypi-publish` validates every file in `dist/`; the checksum manifest is not a wheel/sdist and caused `InvalidDistribution: Unknown distribution format: 'SHA256SUMS'`.

## Test plan
- [ ] Merge to `master`
- [ ] Re-run deploy workflow
- [ ] Confirm TestPyPI publish passes twine validation and uploads successfully


Made with [Cursor](https://cursor.com)