### PR TITLE
New version 2.1.9

### DIFF
--- a/openseries/__init__.py
+++ b/openseries/__init__.py
@@ -1,6 +1,6 @@
 """openseries package initialization."""
 
-__version__ = "2.1.0"
+__version__ = "2.1.9"
 
 from .datefixer import (
     date_fix,

--- a/openseries/load_plotly.py
+++ b/openseries/load_plotly.py
@@ -53,9 +53,9 @@ def load_plotly_dict(
         and logo is the Captor logo dict (may be empty if the remote logo is
         unavailable).
     """
-    project_root = Path(__file__).parent.parent
-    layoutfile = project_root.joinpath("openseries").joinpath("plotly_layouts.json")
-    logofile = project_root.joinpath("openseries").joinpath("plotly_captor_logo.json")
+    package_dir = Path(__file__).parent
+    layoutfile = package_dir / "plotly_layouts.json"
+    logofile = package_dir / "plotly_captor_logo.json"
 
     with layoutfile.open(mode="r", encoding="utf-8") as layout_file:
         fig = load(layout_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openseries"
-version = "2.1.8"
+version = "2.1.9"
 description = "Tools for analyzing financial timeseries."
 authors = [
     { name = "Martin Karrin" },
@@ -83,11 +83,18 @@ docs = [
 ]
 
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=82", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = ["openseries"]
+
 [tool.setuptools.package-data]
-openseries = ["py.typed"]
+openseries = [
+    "py.typed",
+    "plotly_layouts.json",
+    "plotly_captor_logo.json",
+]
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,13 +2,63 @@
 
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
+import sys
+import zipfile
 from importlib.metadata import metadata
 from pathlib import Path
 from re import match
 
+import pytest
+
 
 class PackageTestError(Exception):
     """Custom exception used for signaling test failures."""
+
+
+_PACKAGE_DATA_FILES = (
+    "openseries/plotly_layouts.json",
+    "openseries/plotly_captor_logo.json",
+    "openseries/py.typed",
+)
+
+
+def _venv_executable(venv_dir: Path, name: str) -> Path:
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / f"{name}.exe"
+    return venv_dir / "bin" / name
+
+
+def _prepare_build_tree(build_dir: Path, project_root: Path) -> None:
+    shutil.copytree(project_root / "openseries", build_dir / "openseries")
+    for filename in ("pyproject.toml", "README.md", "LICENSE.md"):
+        shutil.copy2(project_root / filename, build_dir / filename)
+
+
+def _uv_executable() -> str:
+    uv_path = shutil.which("uv")
+    if uv_path is None:
+        msg = "uv executable not found on PATH"
+        raise PackageTestError(msg)
+    return uv_path
+
+
+def _run_checked(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        command,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
 
 
 class TestPackage:
@@ -69,3 +119,88 @@ class TestPackage:
                     f"expected: {package_metadata[name]}"
                 )
                 raise PackageTestError(msg)
+
+    @pytest.mark.xdist_group(name="packaging")
+    def test_wheel_includes_package_data(self: TestPackage, tmp_path: Path) -> None:
+        """Test wheel includes package data files required at runtime."""
+        project_root = Path(__file__).parent.parent
+        build_dir = tmp_path / "project"
+        dist_dir = tmp_path / "dist"
+        build_dir.mkdir()
+        dist_dir.mkdir()
+        _prepare_build_tree(build_dir, project_root)
+
+        _run_checked(
+            [_uv_executable(), "build", "--out-dir", str(dist_dir)],
+            cwd=build_dir,
+        )
+
+        wheel_files = list(dist_dir.glob("*.whl"))
+        if len(wheel_files) != 1:
+            msg = f"Expected one wheel file, found: {wheel_files}"
+            raise PackageTestError(msg)
+
+        with zipfile.ZipFile(wheel_files[0]) as wheel:
+            wheel_names = set(wheel.namelist())
+            missing_files = [
+                filename
+                for filename in _PACKAGE_DATA_FILES
+                if filename not in wheel_names
+            ]
+            if missing_files:
+                msg = f"Wheel missing package data files: {missing_files}"
+                raise PackageTestError(msg)
+
+    @pytest.mark.xdist_group(name="packaging")
+    def test_load_plotly_dict_from_installed_wheel(
+        self: TestPackage,
+        tmp_path: Path,
+    ) -> None:
+        """Test load_plotly_dict works from an installed wheel."""
+        project_root = Path(__file__).parent.parent
+        build_dir = tmp_path / "project"
+        dist_dir = tmp_path / "dist"
+        venv_dir = tmp_path / "venv"
+        build_dir.mkdir()
+        dist_dir.mkdir()
+        _prepare_build_tree(build_dir, project_root)
+
+        _run_checked(
+            [_uv_executable(), "build", "--out-dir", str(dist_dir)],
+            cwd=build_dir,
+        )
+
+        wheel_files = list(dist_dir.glob("*.whl"))
+        if len(wheel_files) != 1:
+            msg = f"Expected one wheel file, found: {wheel_files}"
+            raise PackageTestError(msg)
+
+        _run_checked([sys.executable, "-m", "venv", str(venv_dir)])
+
+        pip = _venv_executable(venv_dir, "pip")
+        python = _venv_executable(venv_dir, "python")
+        _run_checked([str(pip), "install", str(wheel_files[0])])
+
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
+        result = subprocess.run(  # noqa: S603
+            [
+                str(python),
+                "-c",
+                (
+                    "from openseries.load_plotly import load_plotly_dict; "
+                    "fig, _ = load_plotly_dict(); "
+                    "assert 'config' in fig and 'layout' in fig"
+                ),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if result.returncode != 0:
+            msg = (
+                "load_plotly_dict failed from installed wheel: "
+                f"{result.stderr or result.stdout}"
+            )
+            raise PackageTestError(msg)

--- a/uv.lock
+++ b/uv.lock
@@ -804,7 +804,7 @@ wheels = [
 
 [[package]]
 name = "openseries"
-version = "2.1.8"
+version = "2.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "exchange-calendars" },


### PR DESCRIPTION
- Corrected erroneous build configuration that broke version 2.1.8
- Fixed file path in load_plotly.py
- Added packaging tests