### PR TITLE
Remove local pytest artifacts after make test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ update:
 	uv sync --active --locked --extra dev --extra docs
 
 test:
-	pytest
+	pytest; status=$$?; rm -f coverage.xml junit.xml .coverage; exit $$status
 
 lint:
 	ruff check . --fix --exit-non-zero-on-fix

--- a/make.ps1
+++ b/make.ps1
@@ -111,6 +111,9 @@ switch ($task) {
 
     "test" {
         pytest
+        $exitCode = $LASTEXITCODE
+        Remove-Item -Force -ErrorAction SilentlyContinue coverage.xml, junit.xml, .coverage
+        if ($exitCode -ne 0) { exit $exitCode }
     }
 
     "lint" {


### PR DESCRIPTION
Keep coverage.xml and junit.xml for Codecov CI, but drop them plus .coverage after a local test run so they do not linger in the working tree.